### PR TITLE
Add support for opening files on windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ windows-sys = { version = "0.59", features = [
     'Win32_Foundation',
     'Win32_System_Memory',
     'Win32_System_SystemInformation',
+    "Win32_Security"
 ] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -136,7 +136,7 @@ impl Deref for Elf {
 }
 
 // 使用CoreComponentRef是防止出现循环引用
-pub(crate) fn create_lazy_scope<F>(libs: Vec<CoreComponentRef>, pre_find: &F) -> LazyScope
+pub(crate) fn create_lazy_scope<F>(libs: Vec<CoreComponentRef>, pre_find: &'_ F) -> LazyScope<'_>
 where
     F: Fn(&str) -> Option<*const ()>,
 {

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -64,7 +64,7 @@ pub trait Mmap {
         prot: ProtFlags,
         flags: MapFlags,
         offset: usize,
-        fd: Option<i32>,
+        fd: Option<isize>,
         need_copy: &mut bool,
     ) -> Result<NonNull<c_void>>;
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -10,7 +10,7 @@ pub trait ElfObject {
     /// Read data from the elf object
     fn read(&mut self, buf: &mut [u8], offset: usize) -> Result<()>;
     /// Extracts the raw file descriptor.
-    fn as_fd(&self) -> Option<i32>;
+    fn as_fd(&self) -> Option<isize>;
 }
 
 /// The original elf object
@@ -48,7 +48,7 @@ impl<'bytes> ElfObject for ElfBinary<'bytes> {
         &self.name
     }
 
-    fn as_fd(&self) -> Option<i32> {
+    fn as_fd(&self) -> Option<isize> {
         None
     }
 }
@@ -58,7 +58,7 @@ pub struct ElfFile {
     #[allow(unused)]
     pub(crate) name: CString,
     #[allow(unused)]
-    pub(crate) fd: i32,
+    pub(crate) fd: isize,
 }
 
 impl ElfFile {
@@ -68,7 +68,7 @@ impl ElfFile {
     pub unsafe fn from_owned_fd(path: &str, raw_fd: i32) -> Self {
         ElfFile {
             name: CString::new(path).unwrap(),
-            fd: raw_fd,
+            fd: raw_fd as isize,
         }
     }
 

--- a/src/os/bare.rs
+++ b/src/os/bare.rs
@@ -17,7 +17,7 @@ impl Mmap for MmapImpl {
         _prot: ProtFlags,
         flags: MapFlags,
         _offset: usize,
-        _fd: Option<i32>,
+        _fd: Option<isize>,
         need_copy: &mut bool,
     ) -> crate::Result<core::ptr::NonNull<core::ffi::c_void>> {
         *need_copy = true;

--- a/src/os/linux_syscall.rs
+++ b/src/os/linux_syscall.rs
@@ -96,11 +96,11 @@ impl Mmap for MmapImpl {
         prot: ProtFlags,
         flags: MapFlags,
         offset: usize,
-        fd: Option<i32>,
+        fd: Option<isize>,
         need_copy: &mut bool,
     ) -> crate::Result<core::ptr::NonNull<core::ffi::c_void>> {
         let ptr = if let Some(fd) = fd {
-            mmap(addr.unwrap_or(0) as _, len, prot, flags, fd, offset as _)?
+            mmap(addr.unwrap_or(0) as _, len, prot, flags, fd as i32, offset as _)?
         } else {
             *need_copy = true;
             if let Some(addr) = addr {
@@ -211,8 +211,8 @@ impl ElfObject for ElfFile {
         &self.name
     }
 
-    fn as_fd(&self) -> Option<i32> {
-        Some(self.fd)
+    fn as_fd(&self) -> Option<isize> {
+        Some(self.fd as isize)
     }
 }
 /// Converts a raw syscall return value to a result.

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,34 +1,61 @@
 use crate::{
-    Error, Result,
+    Error, Result, io_error,
     mmap::{MapFlags, Mmap, ProtFlags},
-    object::ElfFile,
+    object::{ElfFile, ElfObject},
 };
-use alloc::format;
+use alloc::{ffi::CString, format, string::ToString};
 use core::{
-    ffi::c_void,
-    mem::MaybeUninit,
-    ptr::{NonNull, null},
+    ffi::{CStr, c_void},
+    mem::{self, MaybeUninit},
+    ptr::{NonNull, null, null_mut},
+    str::FromStr,
 };
 use windows_sys::Win32::{
-    Foundation::GetLastError,
+    Foundation::{CloseHandle, GetLastError, HANDLE, TRUE},
+    Security::SECURITY_ATTRIBUTES,
+    Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_BEGIN, FILE_SHARE_READ, GENERIC_READ,
+        OPEN_EXISTING, ReadFile, SetFilePointerEx,
+    },
     System::Memory::{
-        self, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_EXECUTE, PAGE_EXECUTE_READ,
-        PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS, PAGE_READONLY, PAGE_READWRITE,
+        self as Memory, CreateFileMappingW, FILE_MAP_ALL_ACCESS, FILE_MAP_EXECUTE, FILE_MAP_READ,
+        FILE_MAP_WRITE, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, MapViewOfFileEx, PAGE_EXECUTE,
+        PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE, PAGE_PROTECTION_FLAGS, PAGE_READONLY,
+        PAGE_READWRITE,
     },
 };
 
 pub struct MmapImpl;
 
-fn prot_win(prot: ProtFlags) -> PAGE_PROTECTION_FLAGS {
+fn prot_win(prot: ProtFlags, is_create_file_mapping: bool) -> PAGE_PROTECTION_FLAGS {
     match prot.bits() {
         1 => PAGE_READONLY,
         0b10 | 0b11 => PAGE_READWRITE,
-        0b100 => PAGE_EXECUTE,
+        // PAGE_EXECUTE is not supported by the CreateFileMapping function:
+        // https://learn.microsoft.com/en-us/windows/win32/memory/memory-protection-constants.
+        0b100 => {
+            if is_create_file_mapping {
+                PAGE_EXECUTE_READ
+            } else {
+                PAGE_EXECUTE
+            }
+        }
         0b101 => PAGE_EXECUTE_READ,
         0b111 => PAGE_EXECUTE_READWRITE,
         _ => {
-            panic!();
+            panic!("Unsupported protection flags");
         }
+    }
+}
+
+fn prot_to_file_map_access(prot: ProtFlags) -> u32 {
+    match prot.bits() {
+        1 => FILE_MAP_READ,
+        0b10 | 0b11 => FILE_MAP_READ | FILE_MAP_WRITE,
+        0b100 => FILE_MAP_READ | FILE_MAP_EXECUTE,
+        0b101 => FILE_MAP_READ | FILE_MAP_EXECUTE,
+        0b111 => FILE_MAP_ALL_ACCESS,
+        _ => FILE_MAP_READ,
     }
 }
 
@@ -36,28 +63,78 @@ impl Mmap for MmapImpl {
     unsafe fn mmap(
         addr: Option<usize>,
         len: usize,
-        _prot: ProtFlags,
-        _flags: MapFlags,
-        _offset: usize,
-        fd: Option<i32>,
+        prot: ProtFlags,
+        flags: MapFlags,
+        offset: usize,
+        fd: Option<isize>,
         need_copy: &mut bool,
     ) -> Result<NonNull<c_void>> {
-        assert!(fd.is_none());
-        // Currently not support mmap file
-        let ptr = if let Some(addr) = addr {
-            addr as _
-        } else {
-            unsafe {
-                let ptr = Memory::VirtualAlloc(
+        let ptr = if let Some(fd) = fd {
+            let handle = fd as HANDLE;
+            let mut sa = SECURITY_ATTRIBUTES {
+                nLength: mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+                lpSecurityDescriptor: null_mut(),
+                bInheritHandle: TRUE,
+            };
+
+            let mapping_handle = unsafe {
+                CreateFileMappingW(
+                    handle,
+                    &mut sa,
+                    prot_win(prot, true),
+                    (len >> 32) as u32,
+                    (len & 0xFFFFFFFF) as u32,
                     null(),
-                    len,
-                    MEM_RESERVE | MEM_COMMIT,
-                    prot_win(ProtFlags::PROT_WRITE),
-                );
-                ptr
+                )
+            };
+            if mapping_handle == 0 {
+                let err_code = unsafe { GetLastError() };
+                return Err(Error::MmapError {
+                    msg: format!("CreateFileMappingW failed with error: {}", err_code),
+                });
             }
+
+            let desired_addr = addr.unwrap_or(0) as *mut c_void;
+            let file_offset_high = (offset >> 32) as u32;
+            let file_offset_low = (offset & 0xFFFFFFFF) as u32;
+
+            let ptr = unsafe {
+                MapViewOfFileEx(
+                    mapping_handle,
+                    prot_to_file_map_access(prot),
+                    file_offset_high,
+                    file_offset_low,
+                    len,
+                    desired_addr,
+                )
+            };
+
+            unsafe { CloseHandle(mapping_handle) };
+
+            if ptr.Value.is_null() {
+                let err_code = unsafe { GetLastError() };
+                return Err(Error::MmapError {
+                    msg: format!("MapViewOfFileEx failed with error: {}", err_code),
+                });
+            }
+
+            ptr.Value
+        } else {
+            *need_copy = true;
+            if let Some(addr) = addr {
+                addr as _
+            } else {
+                unsafe {
+                    let ptr = Memory::VirtualAlloc(
+                        null(),
+                        len,
+                        MEM_RESERVE | MEM_COMMIT,
+                        prot_win(ProtFlags::PROT_WRITE, false),
+                    );
+                    ptr
+                }
+            };
         };
-        *need_copy = true;
         Ok(NonNull::new(ptr).unwrap())
     }
 
@@ -67,7 +144,8 @@ impl Mmap for MmapImpl {
         prot: ProtFlags,
         _flags: MapFlags,
     ) -> Result<NonNull<c_void>> {
-        let ptr = unsafe { Memory::VirtualAlloc(addr as _, len, MEM_COMMIT, prot_win(prot)) };
+        let ptr =
+            unsafe { Memory::VirtualAlloc(addr as _, len, MEM_COMMIT, prot_win(prot, false)) };
         Ok(NonNull::new(ptr).unwrap())
     }
 
@@ -83,8 +161,9 @@ impl Mmap for MmapImpl {
 
     unsafe fn mprotect(addr: NonNull<c_void>, len: usize, prot: ProtFlags) -> Result<()> {
         let mut old = MaybeUninit::uninit();
-        if unsafe { Memory::VirtualProtect(addr.as_ptr(), len, prot_win(prot), old.as_mut_ptr()) }
-            == 0
+        if unsafe {
+            Memory::VirtualProtect(addr.as_ptr(), len, prot_win(prot, false), old.as_mut_ptr())
+        } == 0
         {
             let err_code = unsafe { GetLastError() };
             return Err(Error::MmapError {
@@ -95,6 +174,112 @@ impl Mmap for MmapImpl {
     }
 }
 
+impl Drop for ElfFile {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.fd as HANDLE) };
+    }
+}
+
 pub(crate) fn from_path(path: &str) -> Result<ElfFile> {
-    todo!()
+    let mut wide_path = Vec::<u16>::with_capacity(path.len() + 1);
+    for c in path.encode_utf16() {
+        wide_path.push(c);
+    }
+    wide_path.push(0);
+
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0,
+        )
+    };
+
+    if handle == 0 {
+        let err_code = unsafe { GetLastError() };
+        return Err(io_error(&format!(
+            "CreateFileW failed with error: {}",
+            err_code
+        )));
+    }
+
+    Ok(ElfFile {
+        name: CString::from_str(path).unwrap(),
+        fd: handle as isize,
+    })
+}
+
+fn win_seek(handle: HANDLE, offset: usize) -> Result<()> {
+    let distance = offset as i64;
+    let mut new_pos = 0i64;
+
+    let res = unsafe { SetFilePointerEx(handle, distance, &mut new_pos, FILE_BEGIN) };
+
+    if res == 0 || new_pos as usize != offset {
+        let err_code = unsafe { GetLastError() };
+        return Err(io_error(&format!(
+            "SetFilePointerEx failed with error: {}",
+            err_code
+        )));
+    }
+    Ok(())
+}
+
+fn win_read_exact(handle: HANDLE, mut bytes: &mut [u8]) -> Result<()> {
+    let mut bytes_read = 0;
+
+    loop {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+
+        let bytes_to_read = bytes.len().min(u32::MAX as usize) as u32;
+        let ptr = bytes.as_mut_ptr();
+        let mut read_count = 0u32;
+
+        let result = unsafe {
+            ReadFile(
+                handle,
+                ptr as *mut c_void,
+                bytes_to_read,
+                &mut read_count,
+                null_mut(),
+            )
+        };
+
+        if result == 0 {
+            let err_code = unsafe { GetLastError() };
+            return Err(io_error(&format!(
+                "ReadFile failed with error: {}",
+                err_code
+            )));
+        } else if read_count == 0 {
+            return Err(io_error("failed to fill buffer"));
+        }
+
+        let n = read_count as usize;
+        bytes_read += n;
+
+        bytes = &mut bytes[n..];
+    }
+}
+
+impl ElfObject for ElfFile {
+    fn read(&mut self, buf: &mut [u8], offset: usize) -> Result<()> {
+        win_seek(self.fd as HANDLE, offset)?;
+        win_read_exact(self.fd as HANDLE, buf)?;
+        Ok(())
+    }
+
+    fn file_name(&self) -> &CStr {
+        &self.name
+    }
+
+    fn as_fd(&self) -> Option<isize> {
+        Some(self.fd)
+    }
 }


### PR DESCRIPTION
Unifies file descriptor types to isize. Additionally, refines lifetime annotations for create_lazy_scope to improve type safety with generic closures and adds the Win32_Security feature to the windows-sys dependency. Implements ElfObject and Drop for ElfFile on windows.